### PR TITLE
Adding power consumption to system_summary data.

### DIFF
--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -78,6 +78,41 @@ I found out the hard way if using hostnames sensors go to `unknown` or `unavaila
     unique_id: heat_pump_working_function
     state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').working_function }}"
   
+  - name: "Heat pump power consumption heating"
+    unique_id: heat_pump_power_consumption_heating
+    state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').power_consumption_heating }}"
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+  
+  - name: "Heat pump power consumption cooling"
+    unique_id: heat_pump_power_consumption_cooling
+    state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').power_consumption_cooling }}"
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+  
+  - name: "Heat pump power consumption tap water"
+    unique_id: heat_pump_power_consumption_tap_water
+    state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').power_consumption_tap_water }}"
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+    
+  - name: "Heat pump power consumption pumps"
+    unique_id: heat_pump_power_consumption_pumps
+    state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').power_consumption_pumps }}"
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+  
+  - name: "Heat pump power consumption total"
+    unique_id: heat_pump_power_consumption_total
+    state: "{{ state_attr('sensor.kronoterm_heat_pump', 'system_info').power_consumption_total }}"
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+  
   # Heating loop 1 (radiators)
   - name: "Heat pump loop 1 current temperature"
     unique_id: heating_loop_1_current_temperature
@@ -108,7 +143,7 @@ I found out the hard way if using hostnames sensors go to `unknown` or `unavaila
     unique_id: heating_loop_1_working_mode
     state: "{{ state_attr('sensor.kronoterm_heat_pump', 'heating_loop_1').working_mode }}"
   
-  # Heating loop 2 (radiators)
+  # Heating loop 2 (convectors)
   - name: "Heat pump loop 2 target temperature"
     unique_id: heating_loop_2_target_temperature
     state: "{{ state_attr('sensor.kronoterm_heat_pump', 'heating_loop_2').target_temp }}"

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -2,4 +2,4 @@
 Flask==3.0.3
 Flask-RESTful==0.3.10
 python-dotenv>=1.0.1
-kronoterm-cloud-api>=0.1.8
+kronoterm-cloud-api>=0.1.10

--- a/src/kronoterm_cloud_relay.py
+++ b/src/kronoterm_cloud_relay.py
@@ -39,6 +39,7 @@ def info_summary() -> dict:
     loop_1_data = hp_api.get_heating_loop_data(HeatingLoop.HEATING_LOOP_1)
     loop_2_data = hp_api.get_heating_loop_data(HeatingLoop.HEATING_LOOP_2)
     alarms_data = hp_api.get_alarms_data()["AlarmsData"]
+    power_consumption_data = hp_api.get_theoretical_power_consumption()
 
     room_temperature = float(system_review_data["TemperaturesAndConfig"]["heating_circle_2_temp"])
     outlet_temperature = float(system_review_data["CurrentFunctionData"][0]["dv_temp"])
@@ -73,6 +74,11 @@ def info_summary() -> dict:
             "sanitary_water_temperature": sanitary_water_temperature,
             "heating_system_pressure": heating_system_pressure,
             "working_function": WorkingFunction(working_function).name,
+            "power_consumption_heating": power_consumption_data.heating,
+            "power_consumption_cooling": power_consumption_data.cooling,
+            "power_consumption_tap_water": power_consumption_data.tap_water,
+            "power_consumption_pumps": power_consumption_data.pumps,
+            "power_consumption_total": power_consumption_data.all,
         },
         "heating_loop_1": {
             "current_temp": heating_loop_1_current_temp,


### PR DESCRIPTION
With kronoterm_cloud_api ver. 0.1.9 following power consumption data is available:
- power_consumption_heating,
- power_consumption_cooling,
- power_consumption_tap_water,
- power_consumption_pumps,
- power_consumption_total