### PR TITLE
Set timezone in docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ services:
     restart: unless-stopped
     ports:
       - "8555:8555"  # Adjust the port mappings as needed
+    ## If you are having problems with slow connection uncomment lines bellow.
+    ## GitHub issue reference [#26](https://github.com/LeskoIam/kronoterm_cloud_relay/issues/26)
+    # extra_hosts:
+    #   - "cloud.kronoterm.com=145.14.48.71"  # TODO: don't forget to periodically check the validity of IP
     environment:
       # Add your kronoterm cloud username and password
-      - KRONOTERM_CLOUD_USER=your-user
-      - KRONOTERM_CLOUD_PASSWORD=your-password
+      - KRONOTERM_CLOUD_USER="your-user"
+      - KRONOTERM_CLOUD_PASSWORD="your-password"
+      - TZ=Europe/Paris   # set to your own timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 ```
 Spin up the image
 ```shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,5 @@ services:
       # Add your kronoterm cloud username and password
       - KRONOTERM_CLOUD_USER="your-user"
       - KRONOTERM_CLOUD_PASSWORD="your-password"
+      - TZ=Europe/Paris   # set to your own timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 


### PR DESCRIPTION
Reported energy in Home Assistant was negative for first hour of the day (00:00 to 01:00), caused by different time zones in docker container.